### PR TITLE
GPII-2322 - Switch to Alpine-based images

### DIFF
--- a/flowmanager-deploy.yml
+++ b/flowmanager-deploy.yml
@@ -11,11 +11,13 @@ spec:
     spec:
       containers:
       - name: flow-manager
-        image: gpii/flow-manager
+        image: gpii/universal
         ports:
         - containerPort: 8081
         env:
-        - name: PREFERENCES_SERVER_HOST_ADDRESS
-          value: preferences.default.svc.cluster.local
         - name: NODE_ENV
-          value: gpii.config.cloudBased.production
+          value: gpii.config.cloudBased.flowManager.production
+        - name: GPII_FLOWMANAGER_PREFERENCES_URL
+          value: http://preferences.default.svc.cluster.local/preferences/%userToken
+        - name: GPII_FLOWMANAGER_LISTEN_PORT
+          value: '8081'

--- a/preferences-deploy.yml
+++ b/preferences-deploy.yml
@@ -11,11 +11,13 @@ spec:
     spec:
       containers:
       - name: preferences
-        image: gpii/preferences-server
+        image: gpii/universal
         ports:
         - containerPort: 8081
         env:
-        - name: COUCHDB_HOST_ADDRESS
-          value: couchdb.default.svc.cluster.local
         - name: NODE_ENV
-          value: gpii.preferencesServer.config.production
+          value: gpii.config.preferencesServer.standalone.production
+        - name: GPII_PREFERENCES_DATASOURCE_URL
+          value: http://couchdb.default.svc.cluster.local:5984/preferences/%userToken
+        - name: GPII_PREFERENCES_LISTEN_PORT
+          value: '8081'


### PR DESCRIPTION
Left over work from GPII-2322.

Just syncing it up with what's already deployed by Ansible [here](https://github.com/inclusive-design/ops/blob/master/ansible/tasks/deploy_gpii_containers.yml)

Tested on Kubernetes 1.7.3